### PR TITLE
Changes necessary to compile on Ubuntu 14.04

### DIFF
--- a/src/common/time.cc
+++ b/src/common/time.cc
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <cerrno>
 
 #include "common/constants.h"
 
@@ -21,7 +22,7 @@ uint64_t GetTimeNS() {
 }
 
 void NanoSleepX(uint64_t sec, uint64_t ns) {
-  struct timespec sleep_req = {sec, ns};
+  struct timespec sleep_req = {(__time_t)sec, (long)ns};
   struct timespec sleep_rem;
   int slept = nanosleep(&sleep_req, &sleep_rem);
   while (slept == -1) {

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 project(mbm_server)
 
 find_package(Threads REQUIRED)
-find_package(Boost COMPONENTS filesystem REQUIRED)
+find_package(Boost COMPONENTS filesystem system REQUIRED)
 
 set(PROJECT_ROOT_DIR ${PROJECT_SOURCE_DIR}/../..)
 

--- a/src/server/cbr.cc
+++ b/src/server/cbr.cc
@@ -48,8 +48,6 @@ bool ValidatePrefix(const char* flagname, const std::string& value) {
   }
 }
 
-const bool prefix_validator = 
-    gflags::RegisterFlagValidator(&FLAGS_prefix, &ValidatePrefix);
 } // namespace
 
 namespace mbm {
@@ -192,8 +190,6 @@ Result RunCBR(const mlab::AcceptedSocket* test_socket,
   uint64_t target_run_length = model::target_run_length(config.cbr_kb_s,
                                                         config.rtt_ms,
                                                         config.mss_bytes);
-  uint64_t target_pipe_size_bytes = target_pipe_size * config.mss_bytes;
-  uint64_t rtt_ns = config.rtt_ms * 1000 * 1000;
 
   // Sending chunk length and traffic volume to client
   ssize_t num_bytes;

--- a/src/server/traffic_generator.cc
+++ b/src/server/traffic_generator.cc
@@ -12,7 +12,10 @@
 #include "common/constants.h"
 #include "common/time.h"
 #include "gflags/gflags.h"
+
+#ifdef USE_WEB100
 #include "server/web100.h"
+#endif  // !USE_WEB100
 
 DECLARE_bool(verbose);
 


### PR DESCRIPTION
- fixes narrowing conversion
- EINTR was undefined so included cerrno
- Fixed CmakeLists.txt to include boost system which seems to now be required
- By default the compiler seems to be treating warnings as errors so deleted unused variables
